### PR TITLE
Test actions and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Initial release of nf-core/metapep, created with the [nf-core](https://nf-co.re/
 
 ### `Added`
 
+- [#1](https://github.com/skrakau/metapep/pull/1) - Download of proteins from NCBI's Entrez databases
+- [#2](https://github.com/skrakau/metapep/pull/2) - Add peptide generationfrom proteins
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base:1.12
+FROM nfcore/base:1.12.1
 LABEL authors="Sabrina Krakau and Leon Kuchenbecker" \
       description="Docker image containing all software requirements for the nf-core/metapep pipeline"
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -255,5 +255,21 @@
         {
             "$ref": "#/definitions/institutional_config_options"
         }
-    ]
+    ],
+    "properties": {
+        "ncbi_key": {
+            "type": "string"
+        },
+        "ncbi_email": {
+            "type": "string"
+        },
+        "min_pep_len": {
+            "type": "integer",
+            "default": 9
+        },
+        "max_pep_len": {
+            "type": "integer",
+            "default": 11
+        }
+    }
 }


### PR DESCRIPTION
Update CHANGELOG. Update `nfcore/base` to `1.12.1` to avoid linting error (why is that? other pipelines also do not always use most recent base images).

To test Github Actions.

