### PR TITLE
Add epitope prediction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,9 @@ RUN conda env export --name nf-core-metapep-1.0dev > nf-core-metapep-1.0dev.yml
 # Instruct R processes to use these empty files instead of clashing with a local version
 RUN touch .Rprofile
 RUN touch .Renviron
+
+# Download MHCflurry models
+ENV MHCFLURRY_DATA_DIR /mhcflurry-data
+ENV MHCFLURRY_DOWNLOADS_CURRENT_RELEASE 1.4.0
+RUN mkdir -p "$MHCFLURRY_DATA_DIR"
+RUN mhcflurry-downloads fetch models_class1

--- a/bin/epytope_predict.py
+++ b/bin/epytope_predict.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+#
+# Author: Leon Kuchenbecker <leon.kuchenbecker@uni-tuebingen.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+####################################################################################################
+# epytope_predict.py
+#
+# This program provides a command line interface to the epitope prediction module of the 'epytope'
+# python framework.
+####################################################################################################
+
+import argparse
+import sys
+import csv
+import warnings
+import contextlib
+import io
+
+####################################################################################################
+
+import logging
+logging.basicConfig(format='%(levelname)s - %(message)s', level=logging.WARNING)
+
+####################################################################################################
+
+import pandas as pd
+import numpy as np
+from Fred2.Core import Allele, Peptide
+from Fred2.EpitopePrediction import EpitopePredictorFactory
+
+####################################################################################################
+
+class AlleleParseException(RuntimeError):
+    """Represents a failure to parse an allele string"""
+    pass
+
+class PredictorCreationException(RuntimeError):
+    """Represents a failure to create an epitope predictor"""
+    pass
+
+class PeptidesParseException(RuntimeError):
+    """Represents a failure to parse the provided peptides file"""
+    pass
+
+####################################################################################################
+
+@contextlib.contextmanager
+def capture_stdout(target):
+    """Captures stdout into specified target file object"""
+    old = sys.stdout
+    try:
+        sys.stdout = target
+        yield
+    finally:
+        sys.stdout = old
+
+def list_available_methods(out = sys.stdout):
+    """Print a list of available epitope prediction methods"""
+    print("The following methods and method versions are available:", file = out)
+    for name,version in EpitopePredictorFactory.available_methods().items():
+        print(name.ljust(50, '.'), "[" + ", ".join(version) + "]", sep="", file = out)
+
+def get_predictor(method, version):
+    """Tries to obtain a predictor based on a method and version descriptor, wraps errors"""
+    try:
+        return EpitopePredictorFactory(method, version=version) if version else EpitopePredictorFactory(method)
+    except Exception as e:
+        raise PredictorCreationException(str(e))
+
+def validate_method(method, version):
+    """Confirm that the specified method / version combination is available and exit accordingly"""
+    try:
+        get_predictor(method, version)
+    except PredictorCreationException:
+        sys.exit(1)
+    sys.exit(0)
+
+def allele_from_string(s):
+    """Obtains an epytope Allele object from a string, handling errors"""
+    try:
+        return Allele(s)
+    except:
+        raise AlleleParseException(s)
+
+def fail(s, exitcode):
+    """Log an error and exit the program with the specified exit code"""
+    logging.error(s)
+    sys.exit(exitcode)
+
+def parse_args():
+    """Parses the command line arguments specified by the user."""
+    parser = argparse.ArgumentParser(description="Perform epitope prediction using the epytope tool bindings.")
+    parser.add_argument("-p", "--peptides", help="Path to file with input peptides. Two input "
+            "formats are supported, a plain text file with one peptide per line or a plain text tsv "
+            "file with two named columns, 'peptide_id' and 'peptide_sequence'. Default: stdin.", type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("-o", "--output", help="Path to the output file. The output file will be a "
+            "plain text tsv file with a column containing either the peptide id or the peptide "
+            "sequence (depending on whether ids were provided in the input), a column with the "
+            "method name and a column for each allele containing the corresponding score. "
+            "Default: stdout.", type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument("-m", "--method", help="Prediction method to use. Default: syfpeithi.", type=str, default="syfpeithi")
+    parser.add_argument("-mv", "--method_version", help="Prediction method version to use. Default: Use method-specific default version.", type=str, default=None)
+    parser.add_argument("-lm", "--list_methods", help="List available methods and versions and exit.", action="store_true")
+    parser.add_argument("-vm", "--validate_method", help="Confirm that the requested method / version is available.", action="store_true")
+
+    parser.add_argument("allele", nargs='*', help="Space separated list of MHC alleles to predict binding scores for.", type=str, default=["A*01:01"])
+
+    return parser.parse_args()
+
+def read_peptides(f):
+    """Reads the peptides from the provided file. The provided file can either be a plain text file
+    with one line per peptide or a plain text tsv file with two columns, `peptide_id` and
+    `peptide_sequence`."""
+    try:
+        peptides = pd.read_csv(f, sep='\t', header=None, comment='#')
+
+        # Guess whether this data comes with IDs
+        nrows, ncols  = peptides.shape
+        if ncols == 1:
+            return None, [ Peptide(x) for x in peptides.iloc[:,0] ]
+        else:
+            peptides.columns = peptides.iloc[0]
+            peptides = peptides.iloc[1:]
+            return list(peptides['peptide_id']), [ Peptide(x) for x in peptides['peptide_sequence'] ]
+    except KeyError as e:
+        raise PeptidesParseException(f"Missing column: {str(e)}. Please provide either a plain list or a table containing named columns 'peptide_id' and 'peptide_sequence'.")
+    except pd.errors.EmptyDataError:
+        raise PeptidesParseException("The file appears to be empty.")
+
+def write_results(outfile, ids, peptides, predictions):
+    """Write the prediction results to the specified output file. If the input peptide sequences
+    were annotated with ids, the ids are written into the output table instead of the sequences."""
+    # Remove the index and rename the columns of the prediction results.
+    predictions.rename({
+        'Seq' : 'peptide_sequence',
+        'Method' : 'method'
+        }, axis=1, inplace=True)
+    # Check if we have ids from the provided input data and write the results accordingly.
+    if ids:
+        id_map = pd.DataFrame({
+            'peptide_id' : ids,
+            'peptide_sequence' : peptides
+            })
+        id_map.merge(predictions).drop('peptide_sequence', axis=1).to_csv(outfile, sep='\t', index=False, na_rep="NA")
+    else:
+        predictions.to_csv(outfile, sep='\t', index=False, na_rep="NA")
+
+####################################################################################################
+
+try:
+    # Parse command line arguments
+    args = parse_args()
+
+    # Validate specified method if requested
+    if args.validate_method:
+        validate_method(method=args.method, version=args.method_version)
+
+    # Print methods if requested
+    if args.list_methods:
+        list_available_methods()
+        sys.exit(0)
+
+    # Parse allele names
+    alleles = [ allele_from_string(allele) for allele in args.allele ]
+
+    # Read peptides from provided input file
+    ids, peptides = read_peptides(args.peptides)
+
+    # Create predictor
+    predictor = get_predictor(method=args.method, version=args.method_version)
+
+    # Run predictor
+    predictor_stdout = io.StringIO()
+    query_peptides_index = pd.DataFrame({'Seq' : peptides}).Seq
+    with warnings.catch_warnings(record=True) as warnings:
+        try:
+            # Redirect stdout output of predictor code to stderr to use stdout
+            # exclusively for the results table if writing to stdout was
+            # specified by the user.
+            with capture_stdout(sys.stderr):
+                predictions = predictor\
+                        .predict(peptides, alleles=alleles)\
+                        .reset_index(1)\
+                        .reindex(query_peptides_index)\
+                        .reset_index()
+            predictions['Method'].fillna(args.method, inplace=True)
+        except ValueError as e:
+            predictions = pd.DataFrame({'Seq': query_peptides_index, 'Method': args.method})
+        for message in { w.message for w in warnings }:
+            logging.warning(f"PREDICTION ({predictor.name} {predictor.version}) - {str(message)}")
+
+    # Add missing alleles as NA values
+    for missing_allele in [ str(allele) for allele in alleles if str(allele) not in predictions.columns ]:
+        logging.warning(f"PREDICTION ({predictor.name} {predictor.version}) yielded no results for allele {missing_allele}")
+        predictions[missing_allele] = np.NaN
+
+    # Write results
+    write_results(args.output, ids, peptides, predictions)
+
+    sys.exit(0)
+except KeyboardInterrupt:
+    fail(f"User requested shutdown.", 1)
+except AlleleParseException as e:
+    fail(f"Failed to parse allele specification '{e}'.", 2)
+except PredictorCreationException as e:
+    fail(f"Failed to find a predictor based on your specification ('{args.method}' version '{args.method_version}')", 3)
+except PeptidesParseException as e:
+    fail(f"The provided input file could not be parsed: {str(e)}", 4)
+except Exception as e:
+    fail(f"UNEXPECTED - {e}", 999)

--- a/bin/gen_prediction_chunks.py
+++ b/bin/gen_prediction_chunks.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# Author: Leon Kuchenbecker <leon.kuchenbecker@uni-tuebingen.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+####################################################################################################
+# epytope_predict.py
+#
+# This program provides a command line interface to the epitope prediction module of the 'epytope'
+# python framework.
+####################################################################################################
+
+import argparse
+import sys
+import os
+
+import pandas as pd
+
+####################################################################################################
+
+def parse_args():
+    """Parses the command line arguments specified by the user."""
+    parser = argparse.ArgumentParser(description="Generate chunks of peptides that are to be predicted against a specified allele.")
+
+    # INPUT FILES
+    parser.add_argument("-p"     , "--peptides"                 , help="Path to the peptides input file"                        , type=str   , required=True)
+    parser.add_argument("-ppo"   , "--protein-peptide-occ"      , help="Path to the protein peptide occurences input file"      , type=str   , required=True)
+    parser.add_argument("-mpo"   , "--microbiome-protein-occ"   , help="Path to the microbiome protein occurences input file"   , type=str   , required=True)
+    parser.add_argument("-c"     , "--conditions"               , help="Path to the conditions input file"                      , type=str   , required=True)
+    parser.add_argument("-cam"   , "--condition-allele-map"     , help="Path to the condition allele map input file"            , type=str   , required=True)
+    parser.add_argument("-a"     , "--alleles"                  , help="Path to the allele input file"                          , type=str   , required=True)
+
+    # OUTPUT FILES
+    parser.add_argument("-o"     , "--outdir"                   , help="Path to the output directory"                           , type=str                      , required=True)
+
+    # PARAMETERS
+    parser.add_argument("-mc"    , "--max-chunk-size"           , help="Maximum chunk size. Default: 5000"                      , type=int                      , default=5000)
+
+    return parser.parse_args()
+
+def write_chunks(data):
+    """Takes data in form of a table of peptide_id, peptide_sequence and
+    identical allele_name values. The data is partitioned into chunks and
+    written into individual output files, prepended with a comment line (#)
+    indicating the allele name."""
+    global cur_chunk
+    for start in range(0, len(data), args.max_chunk_size):
+        with open(os.path.join(args.outdir, "peptides_" + str(cur_chunk).rjust(5,"0") + ".txt"), 'w') as outfile:
+            print(f"#{data.iloc[0].allele_name}#{data.iloc[0].allele_id}", file = outfile)
+            data.iloc[start:start+args.max_chunk_size][["peptide_id", "peptide_sequence"]].to_csv(outfile, sep='\t', index=False)
+            cur_chunk = cur_chunk + 1
+
+####################################################################################################
+
+try:
+    # Parse command line arguments
+    args = parse_args()
+
+    # Read input files
+    peptides                  = pd.read_csv(args.peptides, sep='\t')
+    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, sep='\t')
+    microbiome_protein_occs   = pd.read_csv(args.microbiome_protein_occ, sep='\t')
+    conditions                = pd.read_csv(args.conditions, sep='\t')
+    condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
+    alleles                   = pd.read_csv(args.alleles, sep='\t')
+
+    # Create output directory if it doesn't exist
+    if os.path.exists(args.outdir) and not os.path.isdir(args.outdir):
+        print("ERROR - The target path is not a directory", file = sys.stderr)
+        sys.exit(2)
+    elif not os.path.exists(args.outdir):
+        os.makedirs(args.outdir)
+
+    # Identify which predictions have to be computed
+    to_predict = peptides\
+            .merge(protein_peptide_occs)\
+            .merge(microbiome_protein_occs)\
+            .merge(conditions)\
+            .merge(condition_allele_map)\
+            .merge(alleles)[['peptide_id','peptide_sequence', 'allele_id', 'allele_name']]\
+            .drop_duplicates()
+
+    # Write the necessary predictions into chunks of peptide lists
+    cur_chunk = 0
+    to_predict.groupby("allele_id").apply(write_chunks)
+
+    # We're happy if we got here
+    print(f"All done. Written {len(to_predict)} peptide prediction requests into {cur_chunk} chunks.")
+    sys.exit(0)
+except KeyboardInterrupt:
+    print("\nUser aborted.", file = sys.stderr)
+    sys.exit(1)
+

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,30 @@ dependencies:
   - bioconda::multiqc=1.7
   - conda-forge::biopython=1.78
   - bioconda::prodigal=2.6.3
+# epytope / FRED-2 core dependencies:
+  - bioconda::svmlight=6.02
+  - conda-forge::coincbc=2.10.5
+  - conda-forge::keras=2.3.1
+  - bioconda::csvtk=0.21.0
+  - pip
+  - pip:
+    - git+https://github.com/KohlbacherLab/epytope.git@a863afc5131a33d3510ba0a397cd34bbcaae6270
+    - h5py==2.10.0
+    - joblib==1.0.0
+    - mhcflurry==1.4.3
+    - mhcnames==0.4.8
+    - mhcnuggets==2.3.3
+    - np-utils==0.5.12.1
+    - numpy==1.18.5
+    - opt-einsum==3.3.0
+    - ply==3.11
+    - pymysql==0.10.1
+    - pyomo==5.7.2
+    - pyutilib==6.0.0
+    - pyvcf==0.6.8
+    - scikit-learn==0.24.0
+    - tensorboard==1.15.0
+    - tensorflow==1.15.4
+    - tensorflow-estimator==1.15.1
+    - threadpoolctl==2.1.0
+    - tqdm==4.55.1

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,10 @@ params {
   min_pep_len = 9
   max_pep_len = 11
 
+  // predict epitopes
+  pred_method = 'syfpeithi'
+  pred_chunk_size = 5000
+
   // Boilerplate options
   name = false
   multiqc_config = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -259,6 +259,17 @@
             "type": "integer",
             "default": 11
         },
+        "pred_method": {
+            "type": "string",
+            "default": "syfpeithi",
+	    "description": "Epitope prediction method to use"
+        },
+        "pred_chunk_size": {
+            "type": "integer",
+            "default": 5000,
+	    "description": "Maximum chunk size (#peptides) for epitope prediction jobs"
+        },
+
         "prodigal_mode": {
             "type": "string",
             "default": "meta"


### PR DESCRIPTION
Adds the epitope prediction step to the pipeline.

The PR adds the following paramters to the pipeline:

* `--pred_method`
  Which epitope prediction method to use. It has to be available in epytope / FRED-2.
* `--pred_method_version`
  Which version of the epitope prediction method to use. It has to be available in epytope / FRED-2.
* `--pred_chunk_size`
  Epitope prediction can be performed using data parallelism by splitting the peptide/allele tuples that are to be predicted into chunks. The maximum chunk size can be configured here.

 The PR adds the following processes with the corresponding functionality implemented in Python scripts:

* `pipeline_prechecks`
  Checks whether the specified epitope prediction method / version is legit and otherwise lists the available methods / version. This process blocks the pipeline to prevent avoidable late-stage errors.
* `split_peptides`
  Splits the peptides into chunks for data parallelism
* `predict_epitopes`
  Performs the actual epitope prediction using the epytope / FRED-2 framework. Prediction errors such as alleles or peptide lengths for which no prediction model is available are logged.
* `merge_predictions`
  Merges the prediction results and model error logs from the chunks and publishes them