### PR TITLE
Update test `input.tsv` and add `test_tiny` profile for developing

### DIFF
--- a/conf/test_tiny.config
+++ b/conf/test_tiny.config
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/metapep -profile test_tiny,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on GitHub Actions
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  input = "$projectDir/testdata/input.tiny.tsv"
+  // params 'ncbi_key' and 'ncbi_email' still need to be handed over via command line!
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -85,6 +85,7 @@ profiles {
     podman.enabled = true
   }
   test { includeConfig 'conf/test.config' }
+  test_tiny { includeConfig 'conf/test_tiny.config' }
   test_full { includeConfig 'conf/test_full.config' }
 }
 

--- a/testdata/input.tiny.tsv
+++ b/testdata/input.tiny.tsv
@@ -1,3 +1,4 @@
 condition	type	microbiome_path	alleles	weights_path
 cond_1	taxa	https://github.com/skrakau/metapep/raw/dev/testdata/taxids.small.txt	A*01:01
 cond_2	taxa	https://github.com/skrakau/metapep/raw/dev/testdata/taxids.small.txt	A*01:01,B*07:02
+cond_3	assembly	https://github.com/skrakau/metapep/raw/dev/testdata/test_minigut.contigs.fa.gz	A*01:01	https://github.com/skrakau/metapep/raw/dev/testdata/test_minigut.contig_depths.tsv

--- a/testdata/input.tmp.tsv
+++ b/testdata/input.tmp.tsv
@@ -1,0 +1,4 @@
+condition	type	microbiome_path	alleles	weights_path
+cond_1	taxa	/Users/skrakau/Development/nf-core-metapep/testdata/taxids.small.txt	A*01:01
+cond_2	taxa	/Users/skrakau/Development/nf-core-metapep/testdata/taxids.small.txt	A*01:01,B*07:02
+cond_3	assembly	/Users/skrakau/Workspaces/test_metapep/test_stuff/test_minigut.contigs.fa.gz	A*01:01	/Users/skrakau/Workspaces/test_metapep/test_stuff/MEGAHIT-test_minigut.contig_depths.tsv

--- a/testdata/input.tsv
+++ b/testdata/input.tsv
@@ -2,3 +2,4 @@ condition	type	microbiome_path	alleles	weights_path
 cond_1	taxa	https://github.com/skrakau/metapep/raw/dev/testdata/taxids.txt	A*01:01
 cond_2	taxa	https://github.com/skrakau/metapep/raw/dev/testdata/taxids.small.txt	A*01:01,B*07:02
 cond_3	taxa	https://github.com/skrakau/metapep/raw/dev/testdata/taxids.small.txt	A*01:01
+cond_4	assembly	https://github.com/skrakau/metapep/raw/dev/testdata/test_minigut.contigs.fa.gz	A*01:01	https://github.com/skrakau/metapep/raw/dev/testdata/test_minigut.contig_depths.tsv


### PR DESCRIPTION
- Added assembly test case to input TSV files.

- Added `test_tiny` profile for developing, runs in ~1min: uses only `taxids.small.txt` which contains two taxa with tiny genomes. Since it contains only one genome assembly for each taxon, the other `input.tsv` including `taxids.txt` with taxa that have multiple assemblies listed should be kept for the main test. This new profile is also not run by Github Actions.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)
