### PR TITLE
Move epytope / FRED-2 installation to Dockerfile to avoid linting error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
     strategy:
+      fail-fast: false
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['20.04.0', '']
@@ -65,6 +66,7 @@ jobs:
       NXF_VER: '20.04.0'
       NXF_ANSI_LOG: false
     strategy:
+      fail-fast: false
       matrix:
         tests: ['test_mouse', 'test_assembly_only']   # add further test profiles here, will be run in parallel (but only with one nextflow version)
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL authors="Sabrina Krakau and Leon Kuchenbecker" \
 # Install the conda environment
 COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
+# Manually install epytope / FRED-2 from GH
+RUN /opt/conda/envs/nf-core-metapep-1.0dev/bin/pip install git+https://github.com/KohlbacherLab/epytope.git@a863afc5131a33d3510ba0a397cd34bbcaae6270
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/nf-core-metapep-1.0dev/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -20,9 +20,8 @@ dependencies:
   - conda-forge::coincbc=2.10.5
   - conda-forge::keras=2.3.1
   - bioconda::csvtk=0.21.0
-  - pip
+  - conda-forge::pip=20.3.3
   - pip:
-    - git+https://github.com/KohlbacherLab/epytope.git@a863afc5131a33d3510ba0a397cd34bbcaae6270
     - h5py==2.10.0
     - joblib==1.0.0
     - mhcflurry==1.4.3

--- a/main.nf
+++ b/main.nf
@@ -96,16 +96,16 @@ if (!hasExtension(params.input, "tsv"))
 
 switch (params.pred_method) {
     case "syfpeithi":
-        params.pred_method_version = "1.0";
+        pred_method_version = "1.0";
         break;
     case "mhcflurry":
-        params.pred_method_version = "1.4.3";
+        pred_method_version = "1.4.3";
         break;
     case "mhcnuggets-class-1":
-        params.pred_method_version = "2.3.2";
+        pred_method_version = "2.3.2";
         break;
     case "mhcnuggets-class-2":
-        params.pred_method_version = "2.3.2";
+        pred_method_version = "2.3.2";
         break;
     default:
         exit 1, "Epitope prediction method specified with --pred_method not recognized."
@@ -444,7 +444,6 @@ process predict_epitopes {
 
     script:
     def pred_method           = params.pred_method
-    def pred_method_version   = params.pred_method_version
     """
 
     # Extract allele name from file header


### PR DESCRIPTION
<!--
# nf-core/metapep pull request

Many thanks for contributing to nf-core/metapep!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metapep/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)

* There is currently no Python 3 compatible version of epytope / FRED-2. The pipeline thus uses a pinned commit from the dev branch for now. This PR moves the package installation to the Dockerfile to avoid linting errors based on the unspecified version of the package.
* This PR moves `pred_method_version` out of `params` as it is used only internally