### PR TITLE
Allow 'assembly' input without weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Initial release of nf-core/metapep, created with the [nf-core](https://nf-co.re/
 
 ### `Fixed`
 
+- [#41](https://github.com/skrakau/metapep/pull/41) - Allow `assembly` input without weights
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/bin/create_db_tables.py
+++ b/bin/create_db_tables.py
@@ -66,8 +66,6 @@ def main(args=None):
     for type, weights_path in zip(input_table["type"], input_table["weights_path"]):
         if not type == 'assembly' and not pd.isnull(weights_path):
             sys.exit("Input file " + args.input.name + " contains 'weights_path' specified for type '" + type + "'! Currently input weights are only supported for type 'assembly'.")
-        if type == 'assembly' and pd.isnull(weights_path):
-            sys.exit("Missing 'weights_path' for entry of type 'assembly' in input file " + args.input.name + ". Currently the use of default weights is not supported yet.")
         if not pd.isnull(weights_path) and not weights_path.lower().endswith('.tsv'):
             sys.exit("In " + args.input.name + " specified 'weights_path' " + weights_path + " has invalid file extension. The extension must be '.tsv'.")
 


### PR DESCRIPTION
Allow `assembly` input without weights and assign weights of `1`.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)
