### PR TITLE
Changed cache to 'lenient' for some crucial processes

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -34,11 +34,16 @@ process {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }
     memory = { check_max( 200.GB * task.attempt, 'memory' ) }
     time = { check_max( 10.h * task.attempt, 'time' ) }
+    cache = 'lenient'
   }
   withName:split_pred_tasks {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }
     memory = { check_max( 200.GB * task.attempt, 'memory' ) }
     time = { check_max( 10.h * task.attempt, 'time' ) }
+    cache = 'lenient'
+  }
+  withName:predict_epitopes {
+    cache = 'lenient'
   }
   withName:merge_predictions {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }


### PR DESCRIPTION
Changed cache to `lenient` for some crucial processes. 

On cfc (scratch = true) `generate_peptides` sometimes re-runs despite unchanged input. Seems on some shared filesystems there are problems causes by incorrect timestamps. `lenient` is based only on file path and size.

-> test if this helps

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)
