### PR TITLE
Add extra step to buffer predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Initial release of nf-core/metapep, created with the [nf-core](https://nf-co.re/
 ### `Fixed`
 
 - [#41](https://github.com/skrakau/metapep/pull/41) - Allow `assembly` input without weights
+- [#53](https://github.com/skrakau/metapep/pull/53) - Add buffering of predictions and chunk-wise merging to avoid sbatch error due to too many input files [#52](https://github.com/skrakau/metapep/issues/52)
 
 ### `Dependencies`
 


### PR DESCRIPTION
Add extra step to buffer predictions and merge them chunk-wise to avoid sbatch error due to too many input files for `merge_predicitons` process. See https://github.com/skrakau/metapep/issues/52.



## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)
