### PR TITLE
Handle score distribution plotting for big data

### DIFF
--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Author: Sabrina Krakau
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+####################################################################################################
+
+import argparse
+import sys
+import os
+import csv
+from tqdm import tqdm
+
+import pandas as pd
+
+####################################################################################################
+
+def parse_args(args=None):
+    """Parses the command line arguments specified by the user."""
+    parser = argparse.ArgumentParser(description="Prepare prediction score distribution for plotting.")
+
+    # INPUT FILES
+    parser.add_argument("-p"     , "--predictions"              , help="Path to the predictions input file"                     , type=str   , required=True)
+    parser.add_argument("-ppo"   , "--protein-peptide-occ"      , help="Path to the protein peptide occurences input file"      , type=str   , required=True)
+    parser.add_argument("-mpo"   , "--microbiome-protein-occ"   , help="Path to the microbiome protein occurences input file"   , type=str   , required=True)
+    #parser.add_argument("-c"     , "--conditions"               , help="Path to the conditions input file"                      , type=str   , required=True)
+    #parser.add_argument("-cam"   , "--condition-allele-map"     , help="Path to the condition allele map input file"            , type=str   , required=True)
+    parser.add_argument("-a"     , "--alleles"                  , help="Path to the allele input file"                          , type=str   , required=True)
+
+    # OUTPUT FILES
+    parser.add_argument("-o"     , "--outdir"                   , help="Path to the output directory"                           , type=str   , required=True)
+
+    # PARAMETERS
+    return parser.parse_args()
+
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    # Read input files
+    predictions               = pd.read_csv(args.predictions, sep='\t')
+    protein_peptide_occs      = pd.read_csv(args.protein_peptide_occ, sep='\t').drop(columns="count")
+    microbiome_protein_occs   = pd.read_csv(args.microbiome_protein_occ, sep='\t')
+    #conditions                = pd.read_csv(args.conditions, sep='\t').drop(columns="condition_name")
+    #condition_allele_map      = pd.read_csv(args.condition_allele_map, sep='\t')
+    alleles                   = pd.read_csv(args.alleles, sep='\t')
+
+    # Create output directory if it doesn't exist
+    if os.path.exists(args.outdir) and not os.path.isdir(args.outdir):
+        print("ERROR - The target path is not a directory", file = sys.stderr)
+        sys.exit(2)
+    elif not os.path.exists(args.outdir):
+        os.makedirs(args.outdir)
+
+    print("Joining input data...", file = sys.stderr, flush=True, end='')
+
+    # for each allele separately (to save mem)
+    for allele_id in alleles.allele_id:
+        print("Process allele: ", allele_id, flush=True)
+
+        data = predictions[predictions.allele_id == allele_id] \
+                .drop(columns="allele_id") \
+                .merge(protein_peptide_occs) \
+                .merge(microbiome_protein_occs) \
+                .drop(columns="protein_id") \
+                .groupby(["peptide_id", "prediction_score", "microbiome_id"])["protein_weight"] \
+                .sum() \
+                .reset_index(name="weight_sum") \
+                .drop(columns="peptide_id")
+
+        # missing link: peptide - condition ? not sure ...
+        with open(os.path.join(args.outdir, "prediction_scores.allele_" + str(allele_id) + ".tsv"), 'w') as outfile:
+            data[["prediction_score", "microbiome_id", "weight_sum"]].to_csv(outfile, sep="\t", index=False, header=True)
+
+        microbiome_ids = data.microbiome_id.drop_duplicates()
+        for microbiome_id in microbiome_ids:
+            print("Wrote out ", len(data[data.microbiome_id == microbiome_id]), " prediction scores for microbiome_id ", microbiome_id, ".", flush=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/prepare_score_distribution.py
+++ b/bin/prepare_score_distribution.py
@@ -21,7 +21,6 @@ import argparse
 import sys
 import os
 import csv
-from tqdm import tqdm
 
 import pandas as pd
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -57,6 +57,11 @@ process {
     time = { check_max( 4.h * task.attempt, 'time' ) }
     cache = 'lenient'
   }
+  withName:prepare_score_distribution {
+    cpus = { check_max( 1 * task.attempt, 'cpus' ) }
+    memory = { check_max( 200.GB * task.attempt, 'memory' ) }
+    time = { check_max( 10.h * task.attempt, 'time' ) }
+  }
   withName:plot_score_distribution {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }
     memory = { check_max( 400.GB * task.attempt, 'memory' ) }

--- a/conf/base.config
+++ b/conf/base.config
@@ -64,8 +64,8 @@ process {
   }
   withName:plot_score_distribution {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }
-    memory = { check_max( 400.GB * task.attempt, 'memory' ) }
-    time = { check_max( 10.h * task.attempt, 'time' ) }
+    memory = { check_max( 60.GB * task.attempt, 'memory' ) }
+    time = { check_max( 1.h * task.attempt, 'time' ) }
     cache = 'lenient'
   }
   withName:get_software_versions {

--- a/main.nf
+++ b/main.nf
@@ -550,6 +550,8 @@ process prepare_score_distribution {
     file predictions from ch_predictions
     file proteins_peptides from ch_proteins_peptides
     file proteins_microbiomes from ch_proteins_microbiomes
+    file conditions from  ch_conditions
+    file conditions_alleles from  ch_conditions_alleles
     file alleles from ch_alleles
 
     output:
@@ -560,6 +562,8 @@ process prepare_score_distribution {
     prepare_score_distribution.py --predictions "$predictions" \
                             --protein-peptide-occ "$proteins_peptides" \
                             --microbiome-protein-occ "$proteins_microbiomes" \
+                             --conditions "$conditions" \
+                             --condition-allele-map "$conditions_alleles" \
                             --alleles "$alleles" \
                             --outdir .
     """

--- a/main.nf
+++ b/main.nf
@@ -542,6 +542,31 @@ process merge_predictions {
 /*
  * Generate figures
  */
+
+process prepare_score_distribution {
+    publishDir "${params.outdir}/figures/prediction_scores", mode: params.publish_dir_mode
+
+    input:
+    file predictions from ch_predictions
+    file proteins_peptides from ch_proteins_peptides
+    file proteins_microbiomes from ch_proteins_microbiomes
+    file alleles from ch_alleles
+
+    output:
+    file "prediction_scores.allele_*.tsv"
+
+    script:
+    """
+    prepare_score_distribution.py --predictions "$predictions" \
+                            --protein-peptide-occ "$proteins_peptides" \
+                            --microbiome-protein-occ "$proteins_microbiomes" \
+                            --alleles "$alleles" \
+                            --outdir .
+    """
+}
+
+
+
 process plot_score_distribution {
     publishDir "${params.outdir}/figures", mode: params.publish_dir_mode
 

--- a/main.nf
+++ b/main.nf
@@ -553,7 +553,7 @@ process prepare_score_distribution {
     file alleles from ch_alleles
 
     output:
-    file "prediction_scores.allele_*.tsv"
+    file "prediction_scores.allele_*.tsv" into ch_prep_prediction_scores
 
     script:
     """
@@ -565,32 +565,29 @@ process prepare_score_distribution {
     """
 }
 
-
-
 process plot_score_distribution {
     publishDir "${params.outdir}/figures", mode: params.publish_dir_mode
 
     input:
-    file predictions from ch_predictions
-    file proteins_peptides from ch_proteins_peptides
-    file proteins_microbiomes from ch_proteins_microbiomes
-    file conditions_alleles from ch_conditions_alleles
-    file conditions from ch_conditions
+    file prep_scores from ch_prep_prediction_scores.flatten()
     file alleles from ch_alleles
+    file conditions from ch_conditions
 
     output:
-    file "prediction_score_distribution.pdf"
-    file "prediction_score_distribution.alleles.pdf"
+    file "prediction_score_distribution.allele_*.pdf"
 
     script:
     """
-    plot_score_distribution.R --predictions $predictions \
-                              --proteins_peptides $proteins_peptides \
-                              --proteins_microbiomes $proteins_microbiomes \
-                              --conditions $conditions \
-                              --conditions_alleles $conditions_alleles \
-                              --alleles $alleles \
-                              --method ${params.pred_method}
+    [[ ${prep_scores} =~ prediction_scores.allele_(.*).tsv ]];
+    allele_id="\${BASH_REMATCH[1]}"
+    echo \$allele_id
+
+    plot_score_distribution.R --scores $prep_scores \
+                                   --alleles $alleles \
+                                   --conditions $conditions \
+                                   --allele_id \$allele_id \
+                                   --method ${params.pred_method} \
+                                   --output "prediction_score_distribution.allele_\$allele_id.pdf"
     """
 }
 


### PR DESCRIPTION
Added extra process `prepare_score_distribution` to prepare predictions scores for plotting already in pandas (-> `prediciton_score`, `microbiome_id`, `weight_sum`) to avoid errors in `tidyverse` caused by too large dataframes. This is done for each allele separately, as well as the downstream plotting in `plot_score_distribution`.
 
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/metapep branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/metapep)
